### PR TITLE
add java install + automate emulator port selection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SDK_VERSION=3859397
-OS := $(shell uname -n)
+OS := $(shell lsb_release -is)
 
 .PHONY: all
 all: | amu
@@ -11,14 +11,15 @@ tools: | sdk-tools-linux-$(SDK_VERSION).zip
 	unzip sdk-tools-linux-$(SDK_VERSION).zip
 
 java:
-ifeq ($(OS), ubuntu)
-	sudo apt-get install openjdk-8-jdk
-else
-ifeq ($(OS), debian)
-	sudo apt-get install openjdk-8-jdk
+ifeq ($(OS), Ubuntu)
+	sudo apt-get install -y openjdk-8-jdk
+else ifeq ($(OS), Debian)
+	sudo apt-get install -y openjdk-8-jdk
+else ifeq ($(OS), Fedora)
+	sudo dnf install -y java-1.8.0-openjdk
 else
 	echo "Install Java 1.8.0"
-endif
+	exit 1
 endif
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 SDK_VERSION=3859397
+OS := $(shell uname -n)
 
 .PHONY: all
 all: | amu
@@ -8,6 +9,18 @@ sdk-tools-linux-$(SDK_VERSION).zip:
 
 tools: | sdk-tools-linux-$(SDK_VERSION).zip
 	unzip sdk-tools-linux-$(SDK_VERSION).zip
+
+java:
+ifeq ($(OS), ubuntu)
+	sudo apt-get install openjdk-8-jdk
+else
+ifeq ($(OS), debian)
+	sudo apt-get install openjdk-8-jdk
+else
+	echo "Install Java 1.8.0"
+endif
+endif
+
 
 platforms:
 	echo "y" | ./tools/bin/sdkmanager "platforms;android-26"
@@ -39,7 +52,7 @@ amu: pixel-oreo-26-x86_64
 #	./buildavd.sh
 
 .PHONY: pixel-oreo-26-x86_64
-pixel-oreo-26-x86_64: | tools platforms build-tools platform-tools ~/.android/repositories.cfg tools system-images/android-26/google_apis/x86_64
+pixel-oreo-26-x86_64: | tools java platforms build-tools platform-tools ~/.android/repositories.cfg tools system-images/android-26/google_apis/x86_64
 	DEVICE=pixel \
 	ANDROID_VERSION=8.0.0 \
 	IMAGE_ARCH=x86_64 \

--- a/rundroid.sh
+++ b/rundroid.sh
@@ -9,4 +9,4 @@ if [[ $IMG = "" ]]; then
   echo "IMG environment variable required"
 fi
 
-./tools/emulator -avd $IMG -gpu on -skin 1080x1920
+./tools/emulator -avd $IMG -gpu off -skin 1080x1920 -no-window -noaudio -port 5554 -qemu -vnc :100

--- a/rundroid.sh
+++ b/rundroid.sh
@@ -13,7 +13,6 @@ fi
 firstport=5554
 lastport=5682
 counter=$firstport
-IP=localhost
 # lets assume allocation by 2's - adb low port, console high port
 for ((; counter<=$lastport; counter+=2)); do
     if [[ ! $(netstat -nl | grep $counter) ]]; then
@@ -22,4 +21,16 @@ for ((; counter<=$lastport; counter+=2)); do
 done
 echo "adb port selected:" $counter "console port:" $((counter+1))
 
-./tools/emulator -avd $IMG -gpu off -skin 1080x1920 -no-window -noaudio -ports $counter,$counter+1 -qemu -vnc :100
+vncstart=5900
+vncstop=6200
+vncselect=$vncstart
+for ((; vncselect<=$vncstop; vncselect++)); do
+    if [[ ! $(netstat -nl | grep $vncselect) ]]; then
+        break
+    fi
+done
+vncstart=$((vncselect-vncstart))
+echo "using vnc port:" $vncselect "display:" $vncstart
+
+
+./tools/emulator -avd $IMG -gpu off -skin 1080x1920 -no-window -noaudio -ports $counter,$((counter+1)) -qemu -vnc :$vncstart

--- a/rundroid.sh
+++ b/rundroid.sh
@@ -9,4 +9,17 @@ if [[ $IMG = "" ]]; then
   echo "IMG environment variable required"
 fi
 
-./tools/emulator -avd $IMG -gpu off -skin 1080x1920 -no-window -noaudio -port 5554 -qemu -vnc :100
+# The valid ports range is 5554 to 5682
+firstport=5554
+lastport=5682
+counter=$firstport
+IP=localhost
+# lets assume allocation by 2's - adb low port, console high port
+for ((; counter<=$lastport; counter+=2)); do
+    if [[ ! $(netstat -nl | grep $counter) ]]; then
+        break
+    fi
+done
+echo "adb port selected:" $counter "console port:" $((counter+1))
+
+./tools/emulator -avd $IMG -gpu off -skin 1080x1920 -no-window -noaudio -ports $counter,$counter+1 -qemu -vnc :100


### PR DESCRIPTION
By default requires that java 1.8 is installed - that should be added to the make file.
Other parties can add their package managers for their os (pacman, yum, etc)

Also, emulator does not work by default on headless servers.  Pass in the appropriate qemu options
as well as auto selecting the adb port and vnc port.

Script will break if first adb port is free, but second (which isnt check here) is allocated.